### PR TITLE
Add Codex support to install script

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,27 +18,40 @@ Zero dependencies. 172+ tests. Built for Claude Code.
 
 ## Install
 
-### Via Claude Code CLI
+### Claude Code (recommended)
 
 ```bash
 claude plugin marketplace add karanb192/slack-message-formatter
 claude plugin install slack-message-formatter@slack-message-formatter
 ```
 
-### One-liner (curl)
+### Codex
 
 ```bash
-# Global (all projects)
+curl -sSL https://raw.githubusercontent.com/karanb192/slack-message-formatter/main/install.sh | bash -s codex
+```
+
+### Manual install (curl)
+
+```bash
+# Claude Code global
 curl -sSL https://raw.githubusercontent.com/karanb192/slack-message-formatter/main/install.sh | bash
 
-# Project-level only
+# Codex global
+curl -sSL https://raw.githubusercontent.com/karanb192/slack-message-formatter/main/install.sh | bash -s codex
+
+# Current project only (auto-detects Claude Code or Codex)
 curl -sSL https://raw.githubusercontent.com/karanb192/slack-message-formatter/main/install.sh | bash -s project
 ```
 
 ### Uninstall
 
 ```bash
+# Claude Code
 rm -rf ~/.claude/skills/slack-message-formatter
+
+# Codex
+rm -rf "${CODEX_HOME:-$HOME/.codex}/skills/slack-message-formatter"
 ```
 
 Then in Claude Code, just ask:

--- a/install.sh
+++ b/install.sh
@@ -1,24 +1,47 @@
 #!/bin/bash
-# Install slack-message-formatter skill for Claude Code
-# Usage: curl -sSL https://raw.githubusercontent.com/karanb192/slack-message-formatter/main/install.sh | bash
+# Install slack-message-formatter skill
+#
+# Claude Code (recommended):
+#   claude plugin marketplace add karanb192/slack-message-formatter
+#   claude plugin install slack-message-formatter@slack-message-formatter
+#
+# Manual install (Claude Code or Codex):
+#   curl -sSL https://raw.githubusercontent.com/karanb192/slack-message-formatter/main/install.sh | bash
+#   curl -sSL ... | bash -s codex         # Codex global
+#   curl -sSL ... | bash -s project       # current project only
 
 set -e
 
 REPO="https://github.com/karanb192/slack-message-formatter.git"
 TMP=$(mktemp -d)
-SCOPE="${1:-global}"
+TARGET="${1:-claude}"
 
 echo "Installing slack-message-formatter..."
 
 git clone --depth 1 --quiet "$REPO" "$TMP"
 
-if [ "$SCOPE" = "project" ]; then
-  DEST=".claude/skills/slack-message-formatter"
-  mkdir -p .claude/skills
-else
-  DEST="$HOME/.claude/skills/slack-message-formatter"
-  mkdir -p "$HOME/.claude/skills"
-fi
+case "$TARGET" in
+  codex)
+    CODEX_DIR="${CODEX_HOME:-$HOME/.codex}"
+    DEST="$CODEX_DIR/skills/slack-message-formatter"
+    mkdir -p "$CODEX_DIR/skills"
+    ;;
+  project)
+    # Detect tool: check for .claude/ or .codex/ in current dir
+    if [ -d ".codex" ]; then
+      DEST=".codex/skills/slack-message-formatter"
+      mkdir -p .codex/skills
+    else
+      DEST=".claude/skills/slack-message-formatter"
+      mkdir -p .claude/skills
+    fi
+    ;;
+  *)
+    # Default: Claude Code global
+    DEST="$HOME/.claude/skills/slack-message-formatter"
+    mkdir -p "$HOME/.claude/skills"
+    ;;
+esac
 
 # Remove existing install
 rm -rf "$DEST"
@@ -30,6 +53,10 @@ cp -r "$TMP/skills/slack-message-formatter" "$DEST"
 rm -rf "$TMP"
 
 echo "Installed to $DEST"
-echo "Restart Claude Code to load the skill."
 echo ""
-echo "Usage: ask Claude to 'format a Slack message' or run /slack-message-formatter"
+if echo "$DEST" | grep -q codex; then
+  echo "Restart Codex to load the skill."
+else
+  echo "Restart Claude Code or run /reload-plugins to load the skill."
+fi
+echo "Usage: ask to 'format a Slack message' or run /slack-message-formatter"


### PR DESCRIPTION
## Summary
- Install script now supports Codex: `curl ... | bash -s codex`
- Project-level install auto-detects `.claude/` or `.codex/`
- README updated with separate install sections for Claude Code and Codex

## Test plan
- [x] `bash install.sh` installs to `~/.claude/skills/`
- [x] `bash install.sh codex` installs to `~/.codex/skills/`
- [x] `bash install.sh project` auto-detects tool