### PR TITLE
Document how to refresh the plugin from the marketplace

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,17 @@ curl -sSL https://raw.githubusercontent.com/karanb192/slack-message-formatter/ma
 curl -sSL https://raw.githubusercontent.com/karanb192/slack-message-formatter/main/install.sh | bash -s project
 ```
 
+### Updating
+
+The marketplace tracks the `main` branch of this repo. Claude Code auto-updates marketplace plugins at startup, so most users will pick up changes on their next restart.
+
+To refresh immediately without restarting:
+
+```
+/plugin marketplace update slack-message-formatter
+/reload-plugins
+```
+
 ### Uninstall
 
 ```bash


### PR DESCRIPTION
## Summary
- Adds an **Updating** section to README between Install and Uninstall.
- Clarifies that the marketplace tracks `main` (since `.claude-plugin/marketplace.json` doesn't pin a ref) and auto-updates at startup.
- Gives users the explicit `/plugin marketplace update slack-message-formatter` + `/reload-plugins` commands for an immediate refresh without restarting.

Motivated by users asking how to pick up fixes (e.g. #6) without waiting for the next Claude Code restart.

## Test plan
- [ ] Read the rendered README — Updating section sits between Install and Uninstall and flows naturally
- [ ] Run the two slash commands in Claude Code after a new commit lands on main → plugin reflects the change
- [ ] Fresh Claude Code restart also picks up the new version (auto-update path)